### PR TITLE
Fix build after #2

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,8 @@ APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
 (
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
-    mv "${BUILD_DIR}" "${STAGE}/monorepo" &&
+    mkdir -p "${STAGE}/monorepo" &&
+    mv "${BUILD_DIR}"/* "${STAGE}/monorepo" &&
     rm -rf "${BUILD_DIR}"/* &&
     mv "${STAGE}/$(basename "$APP_BASE")"/* "${BUILD_DIR}" &&
     mv "${STAGE}/monorepo" "${BUILD_DIR}" &&


### PR DESCRIPTION
The change in #2 was based on the upstream fix in:
https://github.com/lstoll/heroku-buildpack-monorepo/pull/13

The upstream change had to be rebased to resolve conflicts, however the conflict resolution did not take into account the new behaviour specific to this fork added in:
https://github.com/YodelTalk/heroku-buildpack-monorepo/commit/98064b31dc6bbfd95040e8a07d0763fa7fb40d31

This change fixes that, and should resolve the error seen after #2:

```
remote: -----> Monorepo app detected
remote: mv: target '/tmp/build_f1e512ef' is not a directory
remote:        FAILED to copy directory into place
```

Refs:
https://github.com/YodelTalk/heroku-buildpack-monorepo/pull/2#issuecomment-809401225